### PR TITLE
Make error reporting in filesystem.py easier to understand

### DIFF
--- a/celery/backends/filesystem.py
+++ b/celery/backends/filesystem.py
@@ -58,8 +58,12 @@ class FilesystemBackend(KeyValueStoreBackend):
         if not url:
             raise ImproperlyConfigured(
                 'You need to configure a path for the File-system backend')
-        if url is not None and url.startswith('file:///'):
+        if url.startswith('file:///'):
             return url[7:]
+        if url.startswith('file://localhost/'):
+            return url[16:]
+        raise ImproperlyConfigured(
+            'A path for the File-system backend should conform to the file URI scheme')
 
     def _do_directory_test(self, key):
         try:


### PR DESCRIPTION
Currently, the ` _find_path` silently returns `None` and then everything fails with "None has no attribute 'encode'", which isn't very clear.